### PR TITLE
Use trigonometry to calculate angle of rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ application.linux64
 application.windows32
 application.windows64
 application.macosx
+build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ application.windows32
 application.windows64
 application.macosx
 build
+*.tmp

--- a/RotatingShape.pde
+++ b/RotatingShape.pde
@@ -1,3 +1,5 @@
+int lastRotationAngle = 0;
+
 void setup() {
   size(600, 400);
 }
@@ -9,6 +11,11 @@ void draw() {
   strokeWeight(4);
 
   stroke(255);
+  fill(255);
+  textSize(20);
+  text(mouseX + ", " + mouseY + ", " + (mouseX + mouseY), 0, 20);
+  text((double)mouseX / width + ", " + (double)mouseY / height, 0, 40);
+
   if (mousePressed) {
     fill(255, 255);
   } else {
@@ -16,8 +23,27 @@ void draw() {
   }
   pushMatrix();
   translate(width / 2, height / 2);
-  rotate(radians((mouseY <= height / 2 ? mouseX : -mouseX) + (mouseX <= width / 2 ? mouseY : -mouseY)));
+  int currentRotationAngle = mouseX + mouseY;
+  // If mouse is below line between top left and bottom right corners, change sign of currentRotationAngle
+  if (((double)mouseX / width) < ((double)mouseY / height)) {
+      currentRotationAngle = -currentRotationAngle;
+  }
+  int resultantRotationAngle = 0;
+  // If currentRotationAngle and lastRotationAngle have different signs then add lastRotationAngle and currentRotationAngle
+  if ((currentRotationAngle > 0) != (lastRotationAngle > 0)) {
+    resultantRotationAngle = lastRotationAngle + currentRotationAngle;
+  } else {
+    resultantRotationAngle = currentRotationAngle;
+  }
+  resultantRotationAngle = resultantRotationAngle % 360;
+  rotate(radians(resultantRotationAngle));
   rectMode(CENTER);
   rect(0, 0, squareSize, squareSize);
   popMatrix();
+
+  // Output calculated angles
+  fill(255);
+  text(lastRotationAngle + ", " + currentRotationAngle + ", " + resultantRotationAngle, 0, 60);
+
+  lastRotationAngle = resultantRotationAngle;
 }

--- a/RotatingShape.pde
+++ b/RotatingShape.pde
@@ -1,42 +1,26 @@
-int lastRotationAngle = 0;
-int rotationAngleOffset = 0;
-boolean mouseWasBelowDiagonal = false;
-
 void setup() {
   size(600, 400);
 }
 
 void draw() {
   final int squareSize = 100;
+  PVector center = new PVector(width / 2, height / 2);
 
   background(50);
   strokeWeight(4);
 
   stroke(255);
-
   if (mousePressed) {
     fill(255, 255);
   } else {
     fill(255, 0);
   }
+
   pushMatrix();
-  translate(width / 2, height / 2);
-  int currentRotationAngle = (mouseX + mouseY) % 360;
-  boolean mouseIsBelowDiagonal = ((double)mouseX / width) < ((double)mouseY / height);
-  if (mouseIsBelowDiagonal) {
-      // If mouse is below line between top left and bottom right corners ("diagonal"), change sign of currentRotationAngle
-      currentRotationAngle = -currentRotationAngle;
-  }
-  int resultantRotationAngle;
-  if (mouseWasBelowDiagonal != mouseIsBelowDiagonal) {
-    rotationAngleOffset = lastRotationAngle - currentRotationAngle;
-  }
-  resultantRotationAngle = (rotationAngleOffset + currentRotationAngle) % 360;
-  rotate(radians(resultantRotationAngle));
+  translate(center.x, center.y);
+  float mouseAngle = atan((mouseY - center.y) / (mouseX - center.x));
+  rotate(mouseAngle);
   rectMode(CENTER);
   rect(0, 0, squareSize, squareSize);
   popMatrix();
-
-  lastRotationAngle = resultantRotationAngle;
-  mouseWasBelowDiagonal = mouseIsBelowDiagonal;
 }

--- a/RotatingShape.pde
+++ b/RotatingShape.pde
@@ -1,4 +1,6 @@
 int lastRotationAngle = 0;
+int rotationAngleOffset = 0;
+boolean mouseWasBelowDiagonal = false;
 
 void setup() {
   size(600, 400);
@@ -23,27 +25,26 @@ void draw() {
   }
   pushMatrix();
   translate(width / 2, height / 2);
-  int currentRotationAngle = mouseX + mouseY;
-  // If mouse is below line between top left and bottom right corners, change sign of currentRotationAngle
-  if (((double)mouseX / width) < ((double)mouseY / height)) {
+  int currentRotationAngle = (mouseX + mouseY) % 360;
+  boolean mouseIsBelowDiagonal = ((double)mouseX / width) < ((double)mouseY / height);
+  if (mouseIsBelowDiagonal) {
+      // If mouse is below line between top left and bottom right corners ("diagonal"), change sign of currentRotationAngle
       currentRotationAngle = -currentRotationAngle;
   }
-  int resultantRotationAngle = 0;
-  // If currentRotationAngle and lastRotationAngle have different signs then add lastRotationAngle and currentRotationAngle
-  if ((currentRotationAngle > 0) != (lastRotationAngle > 0)) {
-    resultantRotationAngle = lastRotationAngle + currentRotationAngle;
-  } else {
-    resultantRotationAngle = currentRotationAngle;
+  int resultantRotationAngle;
+  if (mouseWasBelowDiagonal != mouseIsBelowDiagonal) {
+    rotationAngleOffset = currentRotationAngle + lastRotationAngle;
   }
-  resultantRotationAngle = resultantRotationAngle % 360;
-  rotate(radians(resultantRotationAngle));
+  resultantRotationAngle = (rotationAngleOffset - currentRotationAngle) % 360;
+  rotate(radians(360 - resultantRotationAngle));
   rectMode(CENTER);
   rect(0, 0, squareSize, squareSize);
   popMatrix();
 
   // Output calculated angles
   fill(255);
-  text(lastRotationAngle + ", " + currentRotationAngle + ", " + resultantRotationAngle, 0, 60);
+  text("L:" + lastRotationAngle + ", C:" + currentRotationAngle + ", O:" + rotationAngleOffset + ", R:" + resultantRotationAngle + ", " + (mouseWasBelowDiagonal != mouseIsBelowDiagonal), 0, 60);
 
   lastRotationAngle = resultantRotationAngle;
+  mouseWasBelowDiagonal = mouseIsBelowDiagonal;
 }

--- a/RotatingShape.pde
+++ b/RotatingShape.pde
@@ -4,10 +4,10 @@ void setup() {
 
 void draw() {
   final int squareSize = 100;
-  
+
   background(50);
   strokeWeight(4);
-  
+
   stroke(255);
   if (mousePressed) {
     fill(255, 255);
@@ -16,7 +16,7 @@ void draw() {
   }
   pushMatrix();
   translate(width / 2, height / 2);
-  rotate(radians(mouseX + mouseY));
+  rotate(radians((mouseY <= height / 2 ? mouseX : -mouseX) + (mouseX <= width / 2 ? mouseY : -mouseY)));
   rectMode(CENTER);
   rect(0, 0, squareSize, squareSize);
   popMatrix();

--- a/RotatingShape.pde
+++ b/RotatingShape.pde
@@ -13,10 +13,6 @@ void draw() {
   strokeWeight(4);
 
   stroke(255);
-  fill(255);
-  textSize(20);
-  text(mouseX + ", " + mouseY + ", " + (mouseX + mouseY), 0, 20);
-  text((double)mouseX / width + ", " + (double)mouseY / height, 0, 40);
 
   if (mousePressed) {
     fill(255, 255);
@@ -40,10 +36,6 @@ void draw() {
   rectMode(CENTER);
   rect(0, 0, squareSize, squareSize);
   popMatrix();
-
-  // Output calculated angles
-  fill(255);
-  text("L:" + lastRotationAngle + ", C:" + currentRotationAngle + ", O:" + rotationAngleOffset + ", R:" + resultantRotationAngle + ", " + (mouseWasBelowDiagonal != mouseIsBelowDiagonal), 0, 60);
 
   lastRotationAngle = resultantRotationAngle;
   mouseWasBelowDiagonal = mouseIsBelowDiagonal;

--- a/RotatingShape.pde
+++ b/RotatingShape.pde
@@ -33,10 +33,10 @@ void draw() {
   }
   int resultantRotationAngle;
   if (mouseWasBelowDiagonal != mouseIsBelowDiagonal) {
-    rotationAngleOffset = currentRotationAngle + lastRotationAngle;
+    rotationAngleOffset = lastRotationAngle - currentRotationAngle;
   }
-  resultantRotationAngle = (rotationAngleOffset - currentRotationAngle) % 360;
-  rotate(radians(360 - resultantRotationAngle));
+  resultantRotationAngle = (rotationAngleOffset + currentRotationAngle) % 360;
+  rotate(radians(resultantRotationAngle));
   rectMode(CENTER);
   rect(0, 0, squareSize, squareSize);
   popMatrix();


### PR DESCRIPTION
Change to use `atan` of vertical distance between centre and mouse divided by horizontal distance between centre and mouse, instead of the sum of the mouse x- and y-coordinates added to an "offset" value.
